### PR TITLE
fix pushing to incorrect GH org

### DIFF
--- a/ecrDrydock.txt
+++ b/ecrDrydock.txt
@@ -1,0 +1,5 @@
+postgres
+gitlab
+rabbitmq
+redis
+vault

--- a/ecrShippable.txt
+++ b/ecrShippable.txt
@@ -3,8 +3,3 @@ micro
 mktg
 nexec
 www
-postgres
-gitlab
-rabbitmq
-redis
-vault

--- a/shippable.yml
+++ b/shippable.yml
@@ -325,6 +325,7 @@ jobs:
           script:
             - pushd $(shipctl get_resource_state "shipit_repo")
             - ./tagAndPushSvcs.sh 374168611083.dkr.ecr.us-east-1.amazonaws.com shippable ecrShippable.txt ship_ecr_x86_64_Ubuntu_tag_push
+            - ./tagAndPushSvcs.sh 374168611083.dkr.ecr.us-east-1.amazonaws.com dry-dock ecrDrydock.txt ship_ecr_x86_64_Ubuntu_tag_push
             - popd
 
   - name: genexec_tag_push


### PR DESCRIPTION
to fix the failing job in the pipeline: 

https://app.shippable.com/github/Shippable/jobs/ship_ecr_x86_64_Ubuntu_tag_push/builds/5a7cbcb18abc8b0600a0d4e4/console

job is trying to push tags to GH with the incorrect org