### PR TITLE
adds aarch64 drydock repo as IN for tag-push job

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -467,6 +467,22 @@ jobs:
         switch: off
       - IN: aarch64_u16_repo
         switch: off
+      - IN: aarch64_u16all_img
+        switch: off
+      - IN: aarch64_u16all_repo
+        switch: off
+      - IN: aarch64_u16nodall_img
+        switch: off
+      - IN: aarch64_u16nodall_repo
+        switch: off
+      - IN: aarch64_u16cppall_img
+        switch: off
+      - IN: aarch64_u16cppall_repo
+        switch: off
+      - IN: aarch64_u16pytall_img
+        switch: off
+      - IN: aarch64_u16pytall_repo
+        switch: off
       - IN: aarch64_u16pyt_img
         switch: off
       - IN: aarch64_u16pyt_repo


### PR DESCRIPTION
https://app.shippable.com/github/Shippable/jobs/dry_dh_aarch_64_Ubuntu_tag_push/builds/5a9cb4c9d80d0d0700590a04/console

fixes failing release job