### PR TITLE
Restore admiral_repo to make the archive.prep jobs work

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -20,6 +20,13 @@ resources:
       sourceName: shippable/reqProc
       branch: master
 
+  - name: admiral_repo
+    type: gitRepo
+    integration: avinci_gh
+    versionTemplate:
+      sourceName: "shippable/admiral"
+      branch: master
+
   - name: execTemplates_repo
     type: gitRepo
     integration: avinci_gh


### PR DESCRIPTION
The archive prep jobs are written to expect {name}_repo resources. Restoring it now to make the s3 packaging work again.